### PR TITLE
fix(Interaction): fix syntax error with spring precison grab

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -168,7 +168,7 @@ namespace VRTK
                 SpringJoint tempSpringJoint = obj.AddComponent<SpringJoint>();
                 tempSpringJoint.spring = objectScript.springJointStrength;
                 tempSpringJoint.damper = objectScript.springJointDamper;
-                if(objectScript.grabAttachMechanic == VRTK_InteractableObject.GrabSnapType.Precision_Snap)
+                if(objectScript.grabSnapType == VRTK_InteractableObject.GrabSnapType.Precision_Snap)
                 {
                     tempSpringJoint.anchor = obj.transform.InverseTransformPoint(controllerAttachPoint.position);
                 }


### PR DESCRIPTION
The check should be against the grabSnapType and not the
grabAttachMechanic, otherwise a syntax error occurs.